### PR TITLE
basic libcalls rewritten to live in LUT RAM

### DIFF
--- a/lld/ELF/Arch/P2.cpp
+++ b/lld/ELF/Arch/P2.cpp
@@ -95,12 +95,14 @@ namespace lld {
                 }
                 case R_P2_COG9: {
                     uint32_t inst = read32le(loc);
-                    // TODO: make this more flexible. right now it assumes the COG-based library lives at
-                    // 0x100. Eventually we want to mark any function/variable as being able to live in the cog.
-                    inst += ((val-0x100)/4) & 0x1ff;
+                    // TODO: make this more flexible. Eventually we want to mark any function/variable as being able to live in the cog.
+
+                    // Assumption: libcalls are placed at 0x200 in hub ram. Convert it to a lut address by removing the offset of the hubram address
+                    // divindg by 4 to convert to a cog address, and add 0x200 to get to the LUT address
+                    inst += (((val-0x200)/4) & 0x1ff) + 0x200;
                     LLVM_DEBUG(outs() << "cog function relocation\n");
                     LLVM_DEBUG(outs() << "original value is " << (int)val << "\n");
-                    LLVM_DEBUG(outs() << "adjusted value is " << (int)(((val-0x100)/4) & 0x1ff) << "\n");
+                    LLVM_DEBUG(outs() << "adjusted value is " << (int)((((val-0x200)/4) & 0x1ff) + 0x200) << "\n");
                     write32le(loc, inst);
                     break;
                 }

--- a/llvm/lib/Target/P2/MCTargetDesc/P2AsmBackend.cpp
+++ b/llvm/lib/Target/P2/MCTargetDesc/P2AsmBackend.cpp
@@ -33,7 +33,7 @@
 #define DEBUG_TYPE "p2-asm-backend"
 
 using namespace llvm;
-static unsigned adjustFixupValue(const MCFixup &Fixup, uint64_t Value, bool cogex=false, MCContext *Ctx = nullptr) {
+static unsigned adjustFixupValue(const MCFixup &Fixup, uint64_t Value, MCContext *Ctx = nullptr) {
 
     unsigned Kind = Fixup.getKind();
 
@@ -72,12 +72,8 @@ void P2AsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                         uint64_t Value, bool IsResolved,
                         const MCSubtargetInfo *STI) const {
 
-    // const P2Subtarget *subtarget = static_cast<const P2Subtarget*>(STI);
 
     MCFixupKind Kind = Fixup.getKind();
-    // turns out--you don't need to know if this is hub or cog because of how the JMP instruction works,
-    // but going to leave it in for future potential future use. Don't check if it's cogex for now, since STI seems 
-    // to come in null so need to figure out what to do about that...
     Value = adjustFixupValue(Fixup, Value);
     uint64_t Mask = ((uint64_t)(-1) >> (64 - getFixupKindInfo(Kind).TargetSize));
 
@@ -86,8 +82,6 @@ void P2AsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
 
     LLVM_DEBUG(errs() << "-- applying fixup for ");
     LLVM_DEBUG(Target.dump(); errs() << "\n");
-    // if (subtarget->isCogex())
-    //     LLVM_DEBUG(errs() << "fixup is for a cogex function\n");
 
     LLVM_DEBUG(errs() << "new value is " << Value << "\n");
 

--- a/llvm/lib/Target/P2/MCTargetDesc/P2MCInstLower.cpp
+++ b/llvm/lib/Target/P2/MCTargetDesc/P2MCInstLower.cpp
@@ -215,7 +215,6 @@ void P2MCInstLower::lowerInstruction(const MachineInstr &MI, MCInst &AugMI, MCIn
                 // global addresses that require an AUGS/D to be in inserted to be fixedup later
                 createAugInst(MI, AugMI, i);
             }
-            
         }
 
         if (MCOp.isValid())

--- a/llvm/lib/Target/P2/P2FrameLowering.cpp
+++ b/llvm/lib/Target/P2/P2FrameLowering.cpp
@@ -100,9 +100,9 @@ void P2FrameLowering::emitPrologue(MachineFunction &MF, MachineBasicBlock &MBB) 
     LLVM_DEBUG(MBB.dump());
 
     if (MF.getFunction().hasFnAttribute(Attribute::Cogmain)) {
-        LLVM_DEBUG(errs() << "cog entry function, saving ptra to r0\n");
+        LLVM_DEBUG(errs() << "cog entry function, saving ptra[0] to r0\n");
         DebugLoc DL = MBB.findDebugLoc(MBBI);
-        BuildMI(MBB, MBBI, DL, TII->get(P2::MOVrr))
+        BuildMI(MBB, MBBI, DL, TII->get(P2::RDLONGrr))
             .addReg(P2::R0)
             .addReg(P2::PTRA)
             .addImm(P2::ALWAYS)

--- a/llvm/lib/Target/P2/P2ISelLowering.cpp
+++ b/llvm/lib/Target/P2/P2ISelLowering.cpp
@@ -117,10 +117,11 @@ P2TargetLowering::P2TargetLowering(const P2TargetMachine &TM) : TargetLowering(T
     setOperationAction(ISD::JumpTable, MVT::i32, Custom);
     setOperationAction(ISD::BSWAP, MVT::i32, Expand);
 
-    // setup all the functions that will be libcalls.
-    setOperationAction(ISD::SDIV, MVT::i32, LibCall);
-    setOperationAction(ISD::SREM, MVT::i32, LibCall);
+    setOperationAction(ISD::SDIV, MVT::i32, Expand);
+    setOperationAction(ISD::SREM, MVT::i32, Expand);
+    setOperationAction(ISD::SDIVREM, MVT::i32, Expand);
 
+    // setup all the functions that will be libcalls.
     setLibcallName(RTLIB::SDIV_I32, "__sdiv");
     setLibcallName(RTLIB::SREM_I32, "__srem");
     setLibcallName(RTLIB::MEMCPY, "__memcpy");

--- a/llvm/lib/Target/P2/P2InstrInfo.td
+++ b/llvm/lib/Target/P2/P2InstrInfo.td
@@ -324,6 +324,7 @@ def RFWORD      : P2InstCZD<0b1101011, 0b000010001, (outs P2GPR:$d), (ins), "rfw
 def RFLONG      : P2InstCZD<0b1101011, 0b000010010, (outs P2GPR:$d), (ins), "rflong $d">;
 
 defm SETQ       : P2InstLDm<0b1101011, 0b000101000, "setq">;
+defm SETQ2      : P2InstLDm<0b1101011, 0b000101001, "setq2">;
 
 defm RDLUT      : P2InstCZIDSm<0b1010101, (ins), "rdlut">;
 defm WRLUT      : P2InstLIDSm<0b11000011, "wrlut">;

--- a/llvm/lib/Target/P2/P2MachineFunctionInfo.h
+++ b/llvm/lib/Target/P2/P2MachineFunctionInfo.h
@@ -52,7 +52,7 @@ class P2FunctionInfo : public MachineFunctionInfo {
     /// Size of the callee-saved register portion of the stack frame in bytes.
     unsigned CalleeSavedFrameSize;
 
-    /// this function is a cogex function
+    /// this function is intended to be loaded directly into a cog
     bool cogex;
 
     mutable int DynAllocFI; // Frame index of dynamically allocated stack area.

--- a/llvm/lib/Target/P2/P2Subtarget.cpp
+++ b/llvm/lib/Target/P2/P2Subtarget.cpp
@@ -23,8 +23,8 @@ using namespace llvm;
 
 void P2Subtarget::anchor() {}
 
-P2Subtarget::P2Subtarget(const Triple &TT, const std::string &CPU, const std::string &FS, const P2TargetMachine &TM, bool cogex) :
+P2Subtarget::P2Subtarget(const Triple &TT, const std::string &CPU, const std::string &FS, const P2TargetMachine &TM) :
         P2GenSubtargetInfo(TT, CPU, CPU, FS),
-        FrameLowering(TM), InstrInfo(), TLInfo(TM), is_cogex(cogex) {
+        FrameLowering(TM), InstrInfo(), TLInfo(TM) {
     ParseSubtargetFeatures(CPU, CPU, FS);
 }

--- a/llvm/lib/Target/P2/P2Subtarget.h
+++ b/llvm/lib/Target/P2/P2Subtarget.h
@@ -37,9 +37,6 @@ namespace llvm {
         P2TargetLowering TLInfo;
         SelectionDAGTargetInfo TSInfo;
 
-        // this subtarget is used when compiling "cogtext" functions
-        bool is_cogex;
-
     public:
         // implementation generated in P2GenSubtargetInfo.inc
         void ParseSubtargetFeatures(StringRef CPU, StringRef TuneCPU, StringRef FS);
@@ -47,16 +44,13 @@ namespace llvm {
         /// This constructor initializes the data members to match that
         /// of the specified triple.
         ///
-        P2Subtarget(const Triple &TT, const std::string &CPU, const std::string &FS, const P2TargetMachine &TM, bool cogex);
+        P2Subtarget(const Triple &TT, const std::string &CPU, const std::string &FS, const P2TargetMachine &TM);
 
         const TargetFrameLowering *getFrameLowering() const override { return &FrameLowering; }
         const P2InstrInfo *getInstrInfo() const override { return &InstrInfo; }
         const TargetRegisterInfo *getRegisterInfo() const override { return &InstrInfo.getRegisterInfo(); }
         const P2TargetLowering *getTargetLowering() const override { return &TLInfo; }
         const SelectionDAGTargetInfo *getSelectionDAGInfo() const override { return &TSInfo; }
-
-        bool isCogex() const {return is_cogex;}
-
     };
 
 } // End llvm namespace

--- a/llvm/lib/Target/P2/P2TargetMachine.cpp
+++ b/llvm/lib/Target/P2/P2TargetMachine.cpp
@@ -38,28 +38,18 @@ P2TargetMachine::P2TargetMachine(const Target &T, const Triple &TT, StringRef CP
                                      Optional<CodeModel::Model> CM, CodeGenOpt::Level OL, bool JIT) :
                         LLVMTargetMachine(T, "e-p:32:32-i32:32", TT, CPU, FS, Options, Reloc::Static, CodeModel::Small, OL),
                         TLOF(std::make_unique<P2TargetObjectFile>()),
-                        hubex_subtarget(TT, std::string(CPU), std::string(FS), *this, false),
-                        cogex_subtarget(TT, std::string(CPU), std::string(FS), *this, true) {
-
+                        subtarget(TT, std::string(CPU), std::string(FS), *this) {
     initAsmInfo();
 }
 
 P2TargetMachine::~P2TargetMachine() {}
 
 const P2Subtarget *P2TargetMachine::getSubtargetImpl() const {
-    return &hubex_subtarget;
+    return &subtarget;
 }
 
 const P2Subtarget *P2TargetMachine::getSubtargetImpl(const Function &F) const {
-
-    bool is_cog_func = F.hasFnAttribute(Attribute::Cogtext) || F.hasFnAttribute(Attribute::Cogmain);
-
-    if (is_cog_func) {
-        LLVM_DEBUG(errs() << "--- this is a cog function\n");
-        return &cogex_subtarget;
-    }
-
-    return &hubex_subtarget;
+    return &subtarget;
 }
 
 namespace {

--- a/llvm/lib/Target/P2/P2TargetMachine.h
+++ b/llvm/lib/Target/P2/P2TargetMachine.h
@@ -34,9 +34,7 @@ namespace llvm {
 
         std::unique_ptr<TargetLoweringObjectFile> TLOF;
 
-        // there are two subtargets, one for hubex mode, one for cogex mode
-        P2Subtarget hubex_subtarget;
-        P2Subtarget cogex_subtarget;
+        P2Subtarget subtarget;
 
     public:
         P2TargetMachine(const Target &T, const Triple &TT, StringRef CPU,
@@ -51,19 +49,19 @@ namespace llvm {
         // both subtargets have the same frame lowering, instruction info, etc, etc,
         // so just use the hubex subtarget for now. If that changes, we'll update it here
         const TargetFrameLowering *getFrameLowering() const {
-            return hubex_subtarget.getFrameLowering();
+            return subtarget.getFrameLowering();
         }
         const P2InstrInfo *getInstrInfo() const {
-            return hubex_subtarget.getInstrInfo();
+            return subtarget.getInstrInfo();
         }
         const TargetRegisterInfo *getRegisterInfo() const {
-            return hubex_subtarget.getRegisterInfo();
+            return subtarget.getRegisterInfo();
         }
         const P2TargetLowering *getTargetLowering() const {
-            return hubex_subtarget.getTargetLowering();
+            return subtarget.getTargetLowering();
         }
         const SelectionDAGTargetInfo *getSelectionDAGInfo() const {
-            return hubex_subtarget.getSelectionDAGInfo();
+            return subtarget.getSelectionDAGInfo();
         }
 
         // Pass Pipeline Configuration


### PR DESCRIPTION
LIbcalls are now available in native functions, if INIT_RTLIB is called at the start of the native function