### PR TITLE
Basic symbolizer

### DIFF
--- a/llvm/lib/Target/P2/Disassembler/P2Disassembler.cpp
+++ b/llvm/lib/Target/P2/Disassembler/P2Disassembler.cpp
@@ -380,6 +380,14 @@ bool P2Symbolizer::tryAddingSymbolicOperand(MCInst &Inst,
         return false;
     }
 
+    if (Value == 0) {
+        // If we are disassembling a complete program, branches to 0 are not possible, (except for in custom COG code)
+        // so leave it as 0.
+        // If we are disassembling an object file with fixups, I don't know how to get that data in this function, 
+        // so don't try to create a symbol.
+        return false;
+    }
+
     auto *Symbols = static_cast<SectionSymbolsTy *>(DisInfo);
     if (!Symbols) {
         return false;

--- a/llvm/lib/Target/P2/Disassembler/P2Disassembler.cpp
+++ b/llvm/lib/Target/P2/Disassembler/P2Disassembler.cpp
@@ -32,7 +32,10 @@ typedef MCDisassembler::DecodeStatus DecodeStatus;
 
 namespace {
 
-/// A disassembler class for P2.
+//===----------------------------------------------------------------------===//
+// Class Definitions
+//===----------------------------------------------------------------------===//
+
 class P2Disassembler : public MCDisassembler {
     public:
     	P2Disassembler(const MCSubtargetInfo &STI, MCContext &Ctx) : MCDisassembler(STI, Ctx) {}
@@ -44,14 +47,57 @@ class P2Disassembler : public MCDisassembler {
     };
 }
 
+class P2Symbolizer : public MCSymbolizer {
+private:
+    void *DisInfo;
+    std::vector<uint64_t> ReferencedAddresses;
+
+public:
+    P2Symbolizer(MCContext &Ctx, std::unique_ptr<MCRelocationInfo> &&RelInfo,
+                    void *disInfo)
+                    : MCSymbolizer(Ctx, std::move(RelInfo)), DisInfo(disInfo) {}
+
+    bool tryAddingSymbolicOperand(MCInst &Inst, raw_ostream &cStream,
+                                int64_t Value, uint64_t Address,
+                                bool IsBranch, uint64_t Offset,
+                                uint64_t InstSize) override;
+
+    void tryAddingPcLoadReferenceComment(raw_ostream &cStream,
+                                        int64_t Value,
+                                        uint64_t Address) override;
+
+    ArrayRef<uint64_t> getReferencedAddresses() const override {
+        return ReferencedAddresses;
+    }
+};
+
+//===----------------------------------------------------------------------===//
+// Initialization
+//===----------------------------------------------------------------------===//
+
 static MCDisassembler *createP2Disassembler(const Target &T, const MCSubtargetInfo &STI, MCContext &Ctx) {
 	return new P2Disassembler(STI, Ctx);
 }
 
+static MCSymbolizer *createP2Symbolizer(const Triple &/*TT*/,
+                              LLVMOpInfoCallback /*GetOpInfo*/,
+                              LLVMSymbolLookupCallback /*SymbolLookUp*/,
+                              void *DisInfo,
+                              MCContext *Ctx,
+                              std::unique_ptr<MCRelocationInfo> &&RelInfo) {
+  return new P2Symbolizer(*Ctx, std::move(RelInfo), DisInfo);
+}
+
+
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeP2Disassembler() {
 	// Register the disassembler.
 	TargetRegistry::RegisterMCDisassembler(getTheP2Target(), createP2Disassembler);
+    TargetRegistry::RegisterMCSymbolizer(getTheP2Target(), createP2Symbolizer);
 }
+
+//===----------------------------------------------------------------------===//
+// P2Disassembler
+//===----------------------------------------------------------------------===//
 
 static const uint16_t GPRDecoderTable[] = {
     P2::R0, P2::R1, P2::R2, P2::R3, P2::R4, P2::R5, P2::R6, P2::R7,
@@ -119,9 +165,8 @@ static DecodeStatus DecodeCallInstruction(MCInst &Inst, unsigned Insn, uint64_t 
     unsigned opc = Inst.getOpcode();
     if (opc == P2::CALL || opc == P2::CALLa || opc == P2::CALLAa) {
         // FIXME: make this work.
-        const MCDisassembler *Dis = static_cast<const MCDisassembler*>(Decoder);
-        if (!Dis->tryAddingSymbolicOperand(Inst, a_field, Address, false, 0, 32)) {
-            LLVM_DEBUG(errs() << "unabled to add symbol\n");
+        auto *Dis = static_cast<const P2Disassembler*>(Decoder);
+        if (!Dis->tryAddingSymbolicOperand(Inst, a_field, Address, false, 0, 4)) {
             Inst.addOperand(MCOperand::createImm(a_field));
         }
     } else {
@@ -319,3 +364,42 @@ DecodeStatus P2Disassembler::getInstruction(MCInst &Instr, uint64_t &Size, Array
 
 typedef DecodeStatus (*DecodeFunc)(MCInst &MI, unsigned insn, uint64_t Address, const void *Decoder);
 
+//===----------------------------------------------------------------------===//
+// P2Symbolizer
+//===----------------------------------------------------------------------===//
+
+// Try to find symbol name for specified label
+bool P2Symbolizer::tryAddingSymbolicOperand(MCInst &Inst,
+                                raw_ostream &/*cStream*/, int64_t Value,
+                                uint64_t /*Address*/, bool IsBranch,
+                                uint64_t /*Offset*/, uint64_t /*InstSize*/) {
+
+    if (IsBranch) { // can't do branches
+        return false;
+    }
+
+    auto *Symbols = static_cast<SectionSymbolsTy *>(DisInfo);
+    if (!Symbols) {
+        return false;
+    }
+
+    auto Result = llvm::find_if(*Symbols, [Value](const SymbolInfoTy &Val) {
+        return Val.Addr == static_cast<uint64_t>(Value) && Val.Type == ELF::STT_FUNC;
+    });
+
+    if (Result != Symbols->end()) {
+        auto *Sym = Ctx.getOrCreateSymbol(Result->Name);
+        const auto *Add = MCSymbolRefExpr::create(Sym, Ctx);
+        Inst.addOperand(MCOperand::createExpr(Add));
+        return true;
+    }
+    // Add to list of referenced addresses, so caller can synthesize a label.
+    ReferencedAddresses.push_back(static_cast<uint64_t>(Value));
+    return false;
+}
+
+void P2Symbolizer::tryAddingPcLoadReferenceComment(raw_ostream &cStream,
+                                                       int64_t Value,
+                                                       uint64_t Address) {
+    llvm_unreachable("unimplemented");
+}

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1262,7 +1262,7 @@ static void disassembleObject(const Target *TheTarget, const ObjectFile *Obj,
         unwrapOrError(Section.getContents(), Obj->getFileName()));
 
     std::vector<std::unique_ptr<std::string>> SynthesizedLabelNames;
-    if (Obj->isELF() && Obj->getArch() == Triple::amdgcn) {
+    if (Obj->isELF() && (Obj->getArch() == Triple::amdgcn || Obj->getArch() == Triple::p2)) {
       // AMDGPU disassembler uses symbolizer for printing labels
       addSymbolizer(Ctx, TheTarget, TripleName, DisAsm, SectionAddr, Bytes,
                     Symbols, SynthesizedLabelNames);


### PR DESCRIPTION
Only works on complete executables, not object files with relocations.